### PR TITLE
Some channel/supergroup support

### DIFF
--- a/sender.lua
+++ b/sender.lua
@@ -95,7 +95,9 @@ local Sender = function(ip, port)
 
 		-- Sets the description for a channel/supergroup
 -- TODO: Make work with newline characters.
+-- Use [[]] instead of \n ?
         channel_set_about = function(self, channel_id, about)
+			about = about:gsub('\n', '\\n')
             channel_id = self.channelize(channel_id)
             local command ='channel_set_about channel#%s %q'
             return self.send(self, command:format(channel_id, about))
@@ -119,7 +121,7 @@ local Sender = function(ip, port)
 
         -- Removes a user from a chat
         chat_del_user = function(self, chat_id, user_id)
-            local command = 'chat_del_user _user chat#%s user#%s'
+            local command = 'chat_del_user chat#%s user#%s'
             return self.send(self, command:format(math.abs(chat_id), user_id))
         end,
 
@@ -131,7 +133,7 @@ local Sender = function(ip, port)
 
         --  Sets chat photo. Photo will be cropped to square
         chat_set_photo = function(self, chat_id, filename)
-            local command = 'chat_set_photo %s %s'
+            local command = 'chat_set_photo chat#%s %s'
             return self.send(self, command:format(math.abs(chat_id), filename))
         end,
 

--- a/sender.lua
+++ b/sender.lua
@@ -90,7 +90,20 @@ local Sender = function(ip, port)
 
         -- Quits telegram-cli
         quit = function(self)
-			self.sender:send("quit\n")
+            self.sender:send("quit\n")
+        end,
+
+        -- Downloads a group photo.
+        load_chat_photo = function(self, chat_id)
+            local chat_id = chat_id < 0 and chat_id * -1 or chat_id
+            return self.send(self, "load_chat_photo chat#" .. chat_id)
+        end,
+
+        -- Sets a group photo.
+        chat_set_photo = function(self, chat_id, filename)
+            local chat_id = chat_id < 0 and chat_id * -1 or chat_id
+            local filename = self._filter_text(self, filename)
+            return self.send(self, "chat_set_photo chat#" .. chat_id .. " " .. filename)
         end
     }
 end

--- a/sender.lua
+++ b/sender.lua
@@ -119,7 +119,7 @@ local Sender = function(ip, port)
 
         -- Removes a user from a chat
         chat_del_user = function(self, chat_id, user_id)
-            local command = 'chat_del_user _user chat#%s user#%s'
+            local command = 'chat_del_user chat#%s user#%s'
             return self.send(self, command:format(math.abs(chat_id), user_id))
         end,
 

--- a/sender.lua
+++ b/sender.lua
@@ -95,9 +95,7 @@ local Sender = function(ip, port)
 
 		-- Sets the description for a channel/supergroup
 -- TODO: Make work with newline characters.
--- Use [[]] instead of \n ?
         channel_set_about = function(self, channel_id, about)
-			about = about:gsub('\n', '\\n')
             channel_id = self.channelize(channel_id)
             local command ='channel_set_about channel#%s %q'
             return self.send(self, command:format(channel_id, about))
@@ -200,7 +198,7 @@ local Sender = function(ip, port)
 
         --  Downloads group photo and returns path
         load_chat_photo = function(self, chat_id)
-            local command = 'load_chat_photo %s'
+            local command = 'load_chat_photo chat#%s'
             return self.send(self, command:format(math.abs(chat_id)), true)
         end,
 

--- a/sender.lua
+++ b/sender.lua
@@ -24,7 +24,7 @@ local Sender = function(ip, port)
             self.sender:receive("*l") -- End of output
             return data:gsub('\n$','')
         end,
-        
+
         _filter_text = function(self, str)
             return string.gsub(str, "\\", "\\\\"):gsub("\"", "\\\""):gsub("\n", "\\n"):gsub("\t", "\\t")
         end,
@@ -33,7 +33,7 @@ local Sender = function(ip, port)
         send = function(self, command, reply_id, disable_preview)
             local preview_part = "[enable_preview] "
             local reply_part = ""
-            
+
             if reply_id then
                 if type(reply_id) ~= "number" then
                     print("I need an int for reply_id m8")
@@ -41,11 +41,11 @@ local Sender = function(ip, port)
                     reply_part = "[reply=" .. reply_id .. "] "
                 end
             end
-            
+
             if disable_preview then
                 preview_part = "[disable_preview] "
             end
-            
+
             return self._send(self, reply_part .. preview_part .. command .. "\n")
         end,
 
@@ -86,6 +86,11 @@ local Sender = function(ip, port)
             local chat_id = chat_id < 0 and chat_id * -1 or chat_id
             local new_name = self._filter_text(self, new_name)
             return self.send(self, "rename_chat chat#" .. chat_id .. ' "' .. new_name .. '"')
+        end,
+
+        -- Quits telegram-cli
+        quit = function(self)
+			self.sender:send("quit\n")
         end
     }
 end


### PR DESCRIPTION
Supports the following methods:
- channel_invite
- channel_kick
- channel_set_about
- channel_set_admin
  Also features a function "channelize" to reformat channel IDs for bots to be compliant with tg-cli.
  Additionally, some of the string formatting has been made slightly more elegant.
  Not sure what the deal is with not being able to automerge, but before implementing the new things I took a clean copy of your code.
